### PR TITLE
Feat/jsoniter codec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val catsEffect3Version        = "3.4.1"
 val catsMtlVersion            = "1.2.1"
 val circeVersion              = "0.14.3"
 val http4sVersion             = "0.23.12"
+val jsoniterVersion           = "2.18.0"
 val laminextVersion           = "0.14.3"
 val magnoliaVersion           = "0.17.0"
 val mercatorVersion           = "0.2.1"
@@ -129,15 +130,18 @@ lazy val core = project
       }
     } ++
       Seq(
-        "dev.zio"                     %% "zio"          % zioVersion,
-        "dev.zio"                     %% "zio-streams"  % zioVersion,
-        "dev.zio"                     %% "zio-query"    % zqueryVersion,
-        "dev.zio"                     %% "zio-test"     % zioVersion     % Test,
-        "dev.zio"                     %% "zio-test-sbt" % zioVersion     % Test,
-        "dev.zio"                     %% "zio-json"     % zioJsonVersion % Optional,
-        "com.softwaremill.sttp.tapir" %% "tapir-core"   % tapirVersion   % Optional,
-        "io.circe"                    %% "circe-core"   % circeVersion   % Optional,
-        "io.circe"                    %% "circe-parser" % circeVersion   % Test
+        "dev.zio"                               %% "zio"                   % zioVersion,
+        "dev.zio"                               %% "zio-streams"           % zioVersion,
+        "dev.zio"                               %% "zio-query"             % zqueryVersion,
+        "dev.zio"                               %% "zio-test"              % zioVersion      % Test,
+        "dev.zio"                               %% "zio-test-sbt"          % zioVersion      % Test,
+        "dev.zio"                               %% "zio-json"              % zioJsonVersion  % Optional,
+        "com.softwaremill.sttp.tapir"           %% "tapir-core"            % tapirVersion    % Optional,
+        "io.circe"                              %% "circe-core"            % circeVersion    % Optional,
+        "io.circe"                              %% "circe-parser"          % circeVersion    % Test,
+        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion % Optional,
+        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % jsoniterVersion % Optional,
+        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided
       )
   )
   .dependsOn(macros)

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,6 @@ lazy val core = project
         "io.circe"                              %% "circe-core"            % circeVersion    % Optional,
         "io.circe"                              %% "circe-parser"          % circeVersion    % Test,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterVersion % Optional,
-        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe"  % jsoniterVersion % Optional,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterVersion % Provided
       )
   )

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -102,5 +102,5 @@ object CalibanError extends CalibanErrorJsonCompat {
     caliban.interop.zio.ErrorZioJson.errorValueDecoder.asInstanceOf[F[CalibanError]]
 
   implicit def jsoniterCodec[F[_]](implicit ev: IsJsoniterCodec[F]): F[CalibanError] =
-    caliban.interop.jsoniter.json.errorValueCodec.asInstanceOf[F[CalibanError]]
+    caliban.interop.jsoniter.ErrorJsoniter.errorValueCodec.asInstanceOf[F[CalibanError]]
 }

--- a/core/src/main/scala/caliban/CalibanError.scala
+++ b/core/src/main/scala/caliban/CalibanError.scala
@@ -3,6 +3,7 @@ package caliban
 import caliban.ResponseValue.{ ListValue, ObjectValue }
 import caliban.Value.{ IntValue, StringValue }
 import caliban.interop.circe.{ IsCirceDecoder, IsCirceEncoder }
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import caliban.parsing.adt.LocationInfo
 
@@ -99,4 +100,7 @@ object CalibanError extends CalibanErrorJsonCompat {
     caliban.interop.zio.ErrorZioJson.errorValueEncoder.asInstanceOf[F[CalibanError]]
   implicit def zioJsonDecoder[F[_]](implicit ev: IsZIOJsonDecoder[F]): F[CalibanError] =
     caliban.interop.zio.ErrorZioJson.errorValueDecoder.asInstanceOf[F[CalibanError]]
+
+  implicit def jsoniterCodec[F[_]](implicit ev: IsJsoniterCodec[F]): F[CalibanError] =
+    caliban.interop.jsoniter.json.errorValueCodec.asInstanceOf[F[CalibanError]]
 }

--- a/core/src/main/scala/caliban/GraphQLRequest.scala
+++ b/core/src/main/scala/caliban/GraphQLRequest.scala
@@ -37,7 +37,7 @@ object GraphQLRequest extends GraphQLRequestJsonCompat {
   implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLRequest]       =
     caliban.interop.tapir.schema.requestSchema.asInstanceOf[F[GraphQLRequest]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[GraphQLRequest]   =
-    caliban.interop.jsoniter.json.graphQLRequestCodec.asInstanceOf[F[GraphQLRequest]]
+    caliban.interop.jsoniter.GraphQLRequestJsoniter.graphQLRequestCodec.asInstanceOf[F[GraphQLRequest]]
 
   private[caliban] val ftv1                              = "ftv1"
   private[caliban] val `apollo-federation-include-trace` = "apollo-federation-include-trace"

--- a/core/src/main/scala/caliban/GraphQLRequest.scala
+++ b/core/src/main/scala/caliban/GraphQLRequest.scala
@@ -3,6 +3,7 @@ package caliban
 import caliban.GraphQLRequest.{ `apollo-federation-include-trace`, ftv1 }
 import caliban.Value.StringValue
 import caliban.interop.circe.{ IsCirceDecoder, IsCirceEncoder }
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 
@@ -35,6 +36,8 @@ object GraphQLRequest extends GraphQLRequestJsonCompat {
     caliban.interop.zio.GraphQLRequestZioJson.graphQLRequestEncoder.asInstanceOf[F[GraphQLRequest]]
   implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLRequest]       =
     caliban.interop.tapir.schema.requestSchema.asInstanceOf[F[GraphQLRequest]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[GraphQLRequest]   =
+    caliban.interop.jsoniter.json.graphQLRequestCodec.asInstanceOf[F[GraphQLRequest]]
 
   private[caliban] val ftv1                              = "ftv1"
   private[caliban] val `apollo-federation-include-trace` = "apollo-federation-include-trace"

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -3,6 +3,7 @@ package caliban
 import caliban.ResponseValue._
 import caliban.Value._
 import caliban.interop.circe._
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 
@@ -36,4 +37,6 @@ object GraphQLResponse extends GraphQLResponseJsonCompat {
     caliban.interop.zio.GraphQLResponseZioJson.graphQLResponseDecoder.asInstanceOf[F[GraphQLResponse[E]]]
   implicit def tapirSchema[F[_]: IsTapirSchema, E]: F[GraphQLResponse[E]]       =
     caliban.interop.tapir.schema.responseSchema.asInstanceOf[F[GraphQLResponse[E]]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLResponse[E]]   =
+    caliban.interop.jsoniter.json.graphQLResponseCodec.asInstanceOf[F[GraphQLResponse[E]]]
 }

--- a/core/src/main/scala/caliban/GraphQLResponse.scala
+++ b/core/src/main/scala/caliban/GraphQLResponse.scala
@@ -38,5 +38,5 @@ object GraphQLResponse extends GraphQLResponseJsonCompat {
   implicit def tapirSchema[F[_]: IsTapirSchema, E]: F[GraphQLResponse[E]]       =
     caliban.interop.tapir.schema.responseSchema.asInstanceOf[F[GraphQLResponse[E]]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLResponse[E]]   =
-    caliban.interop.jsoniter.json.graphQLResponseCodec.asInstanceOf[F[GraphQLResponse[E]]]
+    caliban.interop.jsoniter.GraphQLResponseJsoniter.graphQLResponseCodec.asInstanceOf[F[GraphQLResponse[E]]]
 }

--- a/core/src/main/scala/caliban/GraphQLWSInput.scala
+++ b/core/src/main/scala/caliban/GraphQLWSInput.scala
@@ -19,5 +19,5 @@ object GraphQLWSInput extends GraphQLWSInputJsonCompat {
   implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLWSInput]       =
     caliban.interop.tapir.schema.wsInputSchema.asInstanceOf[F[GraphQLWSInput]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLWSInput]   =
-    caliban.interop.jsoniter.json.graphQLWSInputCodec.asInstanceOf[F[GraphQLWSInput]]
+    caliban.interop.jsoniter.GraphQLWSInputJsoniter.graphQLWSInputCodec.asInstanceOf[F[GraphQLWSInput]]
 }

--- a/core/src/main/scala/caliban/GraphQLWSInput.scala
+++ b/core/src/main/scala/caliban/GraphQLWSInput.scala
@@ -1,6 +1,7 @@
 package caliban
 
 import caliban.interop.circe.{ IsCirceDecoder, IsCirceEncoder }
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 
@@ -17,4 +18,6 @@ object GraphQLWSInput extends GraphQLWSInputJsonCompat {
     caliban.interop.zio.GraphQLWSInputZioJson.graphQLWSInputEncoder.asInstanceOf[F[GraphQLWSInput]]
   implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLWSInput]       =
     caliban.interop.tapir.schema.wsInputSchema.asInstanceOf[F[GraphQLWSInput]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLWSInput]   =
+    caliban.interop.jsoniter.json.graphQLWSInputCodec.asInstanceOf[F[GraphQLWSInput]]
 }

--- a/core/src/main/scala/caliban/GraphQLWSOutput.scala
+++ b/core/src/main/scala/caliban/GraphQLWSOutput.scala
@@ -1,20 +1,23 @@
 package caliban
 
 import caliban.interop.circe.{ IsCirceDecoder, IsCirceEncoder }
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.tapir.IsTapirSchema
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 
 case class GraphQLWSOutput(`type`: String, id: Option[String], payload: Option[ResponseValue])
 
 object GraphQLWSOutput extends GraphQLWSOutputJsonCompat {
-  implicit def circeEncoder[F[_]: IsCirceEncoder, E]: F[GraphQLWSOutput]  =
+  implicit def circeEncoder[F[_]: IsCirceEncoder, E]: F[GraphQLWSOutput]   =
     caliban.interop.circe.json.GraphQLWSOutputCirce.graphQLWSOutputEncoder.asInstanceOf[F[GraphQLWSOutput]]
-  implicit def circeDecoder[F[_]: IsCirceDecoder, E]: F[GraphQLWSOutput]  =
+  implicit def circeDecoder[F[_]: IsCirceDecoder, E]: F[GraphQLWSOutput]   =
     caliban.interop.circe.json.GraphQLWSOutputCirce.graphQLWSOutputDecoder.asInstanceOf[F[GraphQLWSOutput]]
-  implicit def zioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[GraphQLWSOutput] =
+  implicit def zioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[GraphQLWSOutput]  =
     caliban.interop.zio.GraphQLWSOutputZioJson.graphQLWSOutputDecoder.asInstanceOf[F[GraphQLWSOutput]]
-  implicit def zioJsonEncoder[F[_]: IsZIOJsonEncoder]: F[GraphQLWSOutput] =
+  implicit def zioJsonEncoder[F[_]: IsZIOJsonEncoder]: F[GraphQLWSOutput]  =
     caliban.interop.zio.GraphQLWSOutputZioJson.graphQLWSOutputEncoder.asInstanceOf[F[GraphQLWSOutput]]
-  implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLWSOutput]       =
+  implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLWSOutput]        =
     caliban.interop.tapir.schema.wsOutputSchema.asInstanceOf[F[GraphQLWSOutput]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLWSOutput] =
+    caliban.interop.jsoniter.json.graphQLWSOuputCodec.asInstanceOf[F[GraphQLWSOutput]]
 }

--- a/core/src/main/scala/caliban/GraphQLWSOutput.scala
+++ b/core/src/main/scala/caliban/GraphQLWSOutput.scala
@@ -19,5 +19,5 @@ object GraphQLWSOutput extends GraphQLWSOutputJsonCompat {
   implicit def tapirSchema[F[_]: IsTapirSchema]: F[GraphQLWSOutput]        =
     caliban.interop.tapir.schema.wsOutputSchema.asInstanceOf[F[GraphQLWSOutput]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec, E]: F[GraphQLWSOutput] =
-    caliban.interop.jsoniter.json.graphQLWSOuputCodec.asInstanceOf[F[GraphQLWSOutput]]
+    caliban.interop.jsoniter.GraphQLWSOutputJsoniter.graphQLWSOuputCodec.asInstanceOf[F[GraphQLWSOutput]]
 }

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -34,7 +34,7 @@ object InputValue extends ValueJsonCompat {
   implicit def inputValueZioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[InputValue] =
     caliban.interop.zio.ValueZIOJson.inputValueDecoder.asInstanceOf[F[InputValue]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[InputValue]             =
-    caliban.interop.jsoniter.json.inputValueCodec.asInstanceOf[F[InputValue]]
+    caliban.interop.jsoniter.ValueJsoniter.inputValueCodec.asInstanceOf[F[InputValue]]
 }
 
 sealed trait ResponseValue { self =>
@@ -85,7 +85,7 @@ object ResponseValue extends ValueJsonCompat {
   implicit def responseValueZioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[ResponseValue] =
     caliban.interop.zio.ValueZIOJson.responseValueDecoder.asInstanceOf[F[ResponseValue]]
   implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[ResponseValue]                =
-    caliban.interop.jsoniter.json.responseValueCodec.asInstanceOf[F[ResponseValue]]
+    caliban.interop.jsoniter.ValueJsoniter.responseValueCodec.asInstanceOf[F[ResponseValue]]
 }
 
 sealed trait Value extends InputValue with ResponseValue

--- a/core/src/main/scala/caliban/Value.scala
+++ b/core/src/main/scala/caliban/Value.scala
@@ -2,6 +2,7 @@ package caliban
 
 import scala.util.Try
 import caliban.interop.circe._
+import caliban.interop.jsoniter.IsJsoniterCodec
 import caliban.interop.zio.{ IsZIOJsonDecoder, IsZIOJsonEncoder }
 import zio.stream.Stream
 
@@ -32,6 +33,8 @@ object InputValue extends ValueJsonCompat {
     caliban.interop.zio.ValueZIOJson.inputValueEncoder.asInstanceOf[F[InputValue]]
   implicit def inputValueZioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[InputValue] =
     caliban.interop.zio.ValueZIOJson.inputValueDecoder.asInstanceOf[F[InputValue]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[InputValue]             =
+    caliban.interop.jsoniter.json.inputValueCodec.asInstanceOf[F[InputValue]]
 }
 
 sealed trait ResponseValue { self =>
@@ -81,6 +84,8 @@ object ResponseValue extends ValueJsonCompat {
     caliban.interop.zio.ValueZIOJson.responseValueEncoder.asInstanceOf[F[ResponseValue]]
   implicit def responseValueZioJsonDecoder[F[_]: IsZIOJsonDecoder]: F[ResponseValue] =
     caliban.interop.zio.ValueZIOJson.responseValueDecoder.asInstanceOf[F[ResponseValue]]
+  implicit def jsoniterCodec[F[_]: IsJsoniterCodec]: F[ResponseValue]                =
+    caliban.interop.jsoniter.json.responseValueCodec.asInstanceOf[F[ResponseValue]]
 }
 
 sealed trait Value extends InputValue with ResponseValue

--- a/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
+++ b/core/src/main/scala/caliban/interop/jsoniter/jsoniter.scala
@@ -1,0 +1,260 @@
+package caliban.interop.jsoniter
+
+import caliban.Value._
+import caliban._
+import caliban.parsing.adt.LocationInfo
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+import scala.collection.immutable.VectorBuilder
+import scala.jdk.CollectionConverters._
+
+/**
+ * This class is an implementation of the pattern described in https://blog.7mind.io/no-more-orphans.html
+ * It makes it possible to mark jsoniter dependency as optional and keep Encoders defined in the companion object.
+ */
+private[caliban] trait IsJsoniterCodec[F[_]]
+private[caliban] object IsJsoniterCodec {
+  implicit val isJsoniterCodec: IsJsoniterCodec[JsonValueCodec] = null
+}
+
+object json {
+
+  private def encodeValue(out: JsonWriter): Value => Unit = {
+    case NullValue           => out.writeNull()
+    case v: IntValue         =>
+      v match {
+        case IntValue.IntNumber(value)    => out.writeVal(value)
+        case IntValue.LongNumber(value)   => out.writeVal(value)
+        case IntValue.BigIntNumber(value) => out.writeVal(value)
+      }
+    case v: FloatValue       =>
+      v match {
+        case FloatValue.FloatNumber(value)      => out.writeVal(value)
+        case FloatValue.DoubleNumber(value)     => out.writeVal(value)
+        case FloatValue.BigDecimalNumber(value) => out.writeVal(value)
+      }
+    case StringValue(value)  => out.writeVal(value)
+    case BooleanValue(value) => out.writeVal(value)
+    case EnumValue(value)    => out.writeVal(value)
+  }
+
+  private def encodeInputValue(out: JsonWriter, depth: Int): InputValue => Unit = {
+    case v: Value                    => encodeValue(out)(v)
+    case InputValue.ListValue(l)     =>
+      val depthM1 = depth - 1
+      if (depthM1 < 0) out.encodeError("depth limit exceeded")
+      out.writeArrayStart()
+      l.foreach(v => encodeInputValue(out, depthM1)(v))
+      out.writeArrayEnd()
+    case InputValue.ObjectValue(o)   =>
+      val depthM1 = depth - 1
+      if (depthM1 < 0) out.encodeError("depth limit exceeded")
+      out.writeObjectStart()
+      o.foreach { case (k, v) =>
+        out.writeKey(k)
+        encodeInputValue(out, depthM1)(v)
+      }
+      out.writeObjectEnd()
+    case InputValue.VariableValue(v) => out.writeVal(v)
+  }
+
+  private def encodeResponseValue(out: JsonWriter, depth: Int): ResponseValue => Unit = {
+    case v: Value                     => encodeValue(out)(v)
+    case ResponseValue.ListValue(l)   =>
+      val depthM1 = depth - 1
+      if (depthM1 < 0) out.encodeError("depth limit exceeded")
+      out.writeArrayStart()
+      l.foreach(v => encodeResponseValue(out, depthM1)(v))
+      out.writeArrayEnd()
+    case ResponseValue.ObjectValue(o) =>
+      val depthM1 = depth - 1
+      if (depthM1 < 0) out.encodeError("depth limit exceeded")
+      out.writeObjectStart()
+      o.foreach { case (k, v) =>
+        out.writeKey(k)
+        encodeResponseValue(out, depthM1)(v)
+      }
+      out.writeObjectEnd()
+    case s: ResponseValue.StreamValue => out.writeVal(s.toString)
+  }
+
+  private val valueTokens: Set[Byte] = Set('"', '-', 't', 'f', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
+  private val emptyInputList         = InputValue.ListValue(Nil)
+  private val emptyInputObject       = InputValue.ObjectValue(Map.empty)
+  private val emptyResponseList      = ResponseValue.ListValue(Nil)
+  private val emptyResponseObject    = ResponseValue.ObjectValue(Nil)
+
+  private def valueDecoder(in: JsonReader): Byte => Value = { b =>
+    if (b == '"') {
+      in.rollbackToken()
+      StringValue(in.readString(null))
+    } else if (b == 'f' || b == 't') {
+      in.rollbackToken()
+      if (in.readBoolean()) BooleanValue(true)
+      else BooleanValue(false)
+    } else if (b >= '0' && b <= '9' || b == '-') {
+      in.rollbackToken()
+      defaultNumberParser(in)
+    } else in.readNullOrError(NullValue, "expected JSON value")
+  }
+
+  private def decodeInputValue(in: JsonReader, depth: Int): InputValue = {
+    val b = in.nextToken()
+    if (valueTokens.contains(b)) {
+      valueDecoder(in)(b)
+    } else if (b == '[') {
+      val depthM1 = depth - 1
+      if (depthM1 < 0) in.decodeError("depth limit exceeded")
+      if (in.isNextToken(']')) emptyInputList
+      else {
+        in.rollbackToken()
+        val x = new VectorBuilder[InputValue]
+        while ({
+          x += decodeInputValue(in, depthM1)
+          in.isNextToken(',')
+        }) ()
+        if (in.isCurrentToken(']')) InputValue.ListValue(x.result().toList)
+        else in.arrayEndOrCommaError()
+      }
+    } else if (b == '{') {
+      val depthM1 = depth - 1
+      if (depthM1 < 0) in.decodeError("depth limit exceeded")
+      if (in.isNextToken('}')) emptyInputObject
+      else {
+        in.rollbackToken()
+        val x = new java.util.LinkedHashMap[String, InputValue](8)
+        while ({
+          x.put(in.readKeyAsString(), decodeInputValue(in, depthM1))
+          in.isNextToken(',')
+        }) ()
+        if (in.isCurrentToken('}')) InputValue.ObjectValue(x.asScala.toMap)
+        else in.objectEndOrCommaError()
+      }
+    } else in.readNullOrError(NullValue, "expected JSON value")
+  }
+
+  private def decodeResponseValue(in: JsonReader, depth: Int): ResponseValue = {
+    val b = in.nextToken()
+    if (valueTokens.contains(b)) {
+      valueDecoder(in)(b)
+    } else if (b == '[') {
+      val depthM1 = depth - 1
+      if (depthM1 < 0) in.decodeError("depth limit exceeded")
+      if (in.isNextToken(']')) emptyResponseList
+      else {
+        in.rollbackToken()
+        val x = new VectorBuilder[ResponseValue]
+        while ({
+          x += decodeResponseValue(in, depthM1)
+          in.isNextToken(',')
+        }) ()
+        if (in.isCurrentToken(']')) ResponseValue.ListValue(x.result().toList)
+        else in.arrayEndOrCommaError()
+      }
+    } else if (b == '{') {
+      val depthM1 = depth - 1
+      if (depthM1 < 0) in.decodeError("depth limit exceeded")
+      if (in.isNextToken('}')) emptyResponseObject
+      else {
+        in.rollbackToken()
+        val x = new java.util.LinkedHashMap[String, ResponseValue](8)
+        while ({
+          x.put(in.readKeyAsString(), decodeResponseValue(in, depthM1))
+          in.isNextToken(',')
+        }) ()
+        if (in.isCurrentToken('}')) ResponseValue.ObjectValue(x.asScala.toList)
+        else in.objectEndOrCommaError()
+      }
+    } else in.readNullOrError(NullValue, "expected JSON value")
+  }
+
+  private val defaultNumberParser: JsonReader => Value = in => {
+    in.setMark()
+    var digits = 0
+    var b      = in.nextByte()
+    if (b == '-') b = in.nextByte()
+    try while (b >= '0' && b <= '9') {
+      b = in.nextByte()
+      digits += 1
+    } catch {
+      case _: JsonReaderException => // ignore the end of input error for now
+    }
+    in.rollbackToMark()
+
+    if ((b | 0x20) != 'e' && b != '.') {
+      if (digits < 19) {
+        if (digits < 10) Value.IntValue.IntNumber(in.readInt())
+        else Value.IntValue.LongNumber(in.readLong())
+      } else {
+        val x = in.readBigInt(null)
+        if (x.bitLength < 64) Value.IntValue.LongNumber(x.longValue)
+        else Value.IntValue.BigIntNumber(x.bigInteger)
+      }
+    } else Value.FloatValue.BigDecimalNumber(in.readBigDecimal(null).bigDecimal)
+  }
+
+  val inputValueCodec: JsonValueCodec[InputValue] = new JsonValueCodec[InputValue] {
+    override def decodeValue(in: JsonReader, default: InputValue): InputValue = decodeInputValue(in, 1024)
+    override def encodeValue(x: InputValue, out: JsonWriter): Unit            = encodeInputValue(out, 1024)(x)
+    override def nullValue: InputValue                                        = NullValue
+  }
+
+  val responseValueCodec: JsonValueCodec[ResponseValue] = new JsonValueCodec[ResponseValue] {
+    override def decodeValue(in: JsonReader, default: ResponseValue): ResponseValue = decodeResponseValue(in, 1024)
+    override def encodeValue(x: ResponseValue, out: JsonWriter): Unit               = encodeResponseValue(out, 1024)(x)
+    override def nullValue: ResponseValue                                           = NullValue
+  }
+
+  private case class DeserializedError(
+    message: String,
+    path: Option[List[Either[String, Int]]],
+    locations: Option[List[LocationInfo]],
+    extensions: Option[ResponseValue.ObjectValue]
+  )
+
+  implicit val errorValueCodec: JsonValueCodec[CalibanError] = new JsonValueCodec[CalibanError] {
+    private val errorProxyCodec: JsonValueCodec[DeserializedError] = JsonCodecMaker.make
+
+    override def decodeValue(in: JsonReader, default: CalibanError): CalibanError = {
+      val err = errorProxyCodec.decodeValue(in, null)
+      CalibanError.ExecutionError(
+        msg = err.message,
+        path = err.path.getOrElse(Nil),
+        locationInfo = err.locations.flatMap(_.headOption),
+        innerThrowable = None,
+        extensions = err.extensions
+      )
+    }
+    override def encodeValue(x: CalibanError, out: JsonWriter): Unit              =
+      responseValueCodec.encodeValue(x.toResponseValue, out)
+    override def nullValue: CalibanError                                          = null.asInstanceOf[CalibanError]
+  }
+
+  private case class GraphQLResponseProxy(data: ResponseValue, errors: Option[List[CalibanError]])
+
+  implicit val graphQLResponseCodec: JsonValueCodec[GraphQLResponse[CalibanError]] =
+    new JsonValueCodec[GraphQLResponse[CalibanError]] {
+      private val proxyCodec: JsonValueCodec[GraphQLResponseProxy]                      = JsonCodecMaker.make
+      override def decodeValue(
+        in: JsonReader,
+        default: GraphQLResponse[CalibanError]
+      ): GraphQLResponse[CalibanError] = {
+        val resp = proxyCodec.decodeValue(in, null)
+        GraphQLResponse[CalibanError](
+          data = resp.data,
+          errors = resp.errors.getOrElse(Nil),
+          extensions = None
+        )
+      }
+      override def encodeValue(x: GraphQLResponse[CalibanError], out: JsonWriter): Unit =
+        responseValueCodec.encodeValue(x.toResponseValue, out)
+      override def nullValue: GraphQLResponse[CalibanError]                             =
+        null.asInstanceOf[GraphQLResponse[CalibanError]]
+    }
+
+  implicit val graphQLRequestCodec: JsonValueCodec[GraphQLRequest]      = JsonCodecMaker.make
+  implicit val graphQLWSInputCodec: JsonValueCodec[GraphQLWSInput]      = JsonCodecMaker.make
+  implicit val graphQLWSOuputCodec: JsonValueCodec[GraphQLWSOutput]     = JsonCodecMaker.make
+  implicit val stringMapCodec: JsonValueCodec[Map[String, Seq[String]]] = JsonCodecMaker.make
+}

--- a/core/src/main/scala/caliban/interop/tapir/tapir.scala
+++ b/core/src/main/scala/caliban/interop/tapir/tapir.scala
@@ -9,7 +9,7 @@ import sttp.tapir.{ Schema, SchemaType }
  */
 private[caliban] trait IsTapirSchema[F[_]]
 private[caliban] object IsTapirSchema {
-  implicit val isCirceEncoder: IsTapirSchema[Schema] = null
+  implicit val isTapirSchema: IsTapirSchema[Schema] = null
 }
 
 object schema {

--- a/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
+++ b/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
@@ -35,7 +35,7 @@ object GraphQLRequestCirceSpec extends ZIOSpecDefault {
         )
 
         assertTrue(
-          res.asJson.noSpaces == """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null},"extensions":null}"""
+          res.asJson.noSpaces == """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null}}"""
         )
       }
     )

--- a/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
+++ b/core/src/test/scala/caliban/interop/circe/GraphQLRequestCirceSpec.scala
@@ -35,7 +35,7 @@ object GraphQLRequestCirceSpec extends ZIOSpecDefault {
         )
 
         assertTrue(
-          res.asJson.noSpaces == """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null}}"""
+          res.asJson.noSpaces == """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null},"extensions":null}"""
         )
       }
     )

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLRequestJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLRequestJsoniterSpec.scala
@@ -1,0 +1,52 @@
+package caliban.interop.jsoniter
+
+import caliban.{ GraphQLRequest, Value }
+import com.github.plokhotnyuk.jsoniter_scala.core.{ readFromString, writeToString }
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, assertTrue, ZIOSpecDefault }
+
+object GraphQLRequestJsoniterSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("GraphQLRequestJsoniterSpec")(
+      test("can be parsed from JSON by jsoniter") {
+        val request =
+          """{"query": "{}", "operationName": "op", "variables": {"hello":"world","answer":42,"isAwesome":true, "name": null}}"""
+        assert(readFromString[GraphQLRequest](request))(
+          equalTo(
+            GraphQLRequest(
+              query = Some("{}"),
+              operationName = Some("op"),
+              variables = Some(
+                Map(
+                  "hello"     -> Value.StringValue("world"),
+                  "answer"    -> Value.IntValue(42),
+                  "isAwesome" -> Value.BooleanValue(true),
+                  "name"      -> Value.NullValue
+                )
+              )
+            )
+          )
+        )
+      },
+      test("can encode to JSON by jsoniter") {
+        val res = GraphQLRequest(
+          query = Some("{}"),
+          operationName = Some("op"),
+          variables = Some(
+            Map(
+              "hello"     -> Value.StringValue("world"),
+              "answer"    -> Value.IntValue(42),
+              "isAwesome" -> Value.BooleanValue(true),
+              "name"      -> Value.NullValue
+            )
+          )
+        )
+
+        assertTrue(
+          writeToString(res) ==
+            """{"query":"{}","operationName":"op","variables":{"hello":"world","answer":42,"isAwesome":true,"name":null}}"""
+        )
+      }
+    )
+}

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLResponseJsoniterSpec.scala
@@ -1,0 +1,99 @@
+package caliban.interop.jsoniter
+
+import caliban.CalibanError.ExecutionError
+import caliban.ResponseValue.{ ListValue, ObjectValue }
+import caliban.Value.{ IntValue, StringValue }
+import caliban.parsing.adt.LocationInfo
+import caliban.{ CalibanError, GraphQLResponse }
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, assertTrue, ZIOSpecDefault }
+
+object GraphQLResponseJsoniterSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("GraphQLResponseJsoniterSpec")(
+      test("can be converted to JSON [jsoniter]") {
+        val response = GraphQLResponse(StringValue("data"), Nil)
+        assertTrue(writeToString(response) == """{"data":"data"}""")
+      },
+      test("should include error objects for every error, including extensions [jsoniter]") {
+        val errorExtensions = List(
+          ("errorCode", StringValue("TEST_ERROR")),
+          ("myCustomKey", StringValue("my-value"))
+        )
+
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List(
+            ExecutionError(
+              "Resolution failed",
+              locationInfo = Some(LocationInfo(1, 2)),
+              extensions = Some(ObjectValue(errorExtensions))
+            )
+          )
+        )
+
+        assertTrue(
+          writeToString(response) ==
+            """{"data":"data","errors":[{"message":"Resolution failed","locations":[{"line":2,"column":1}],"extensions":{"errorCode":"TEST_ERROR","myCustomKey":"my-value"}}]}"""
+        )
+      },
+      test("should not include errors element when there are none [jsoniter]") {
+        val response = GraphQLResponse(
+          StringValue("data"),
+          List.empty
+        )
+
+        assertTrue(writeToString(response) == """{"data":"data"}""")
+      },
+      test("can be parsed from JSON [jsoniter]") {
+        val req =
+          """
+            |{
+            |   "data":{"value": 42},
+            |   "errors":[
+            |     {
+            |       "message":"boom",
+            |       "path": ["step", 0],
+            |       "locations": [{"column": 1, "line": 2}],
+            |       "extensions": {
+            |         "argumentName": "id",
+            |         "code": "BAD_USER_INPUT",
+            |         "exception": {
+            |           "stacktrace": [
+            |              "trace"
+            |           ]
+            |         }
+            |       }
+            |     }]
+            |}""".stripMargin
+
+        assert(readFromString[GraphQLResponse[CalibanError]](req))(
+          equalTo(
+            GraphQLResponse(
+              data = ObjectValue(List("value" -> IntValue("42"))),
+              errors = List(
+                ExecutionError(
+                  "boom",
+                  path = List(Left("step"), Right(0)),
+                  locationInfo = Some(LocationInfo(1, 2)),
+                  extensions = Some(
+                    ObjectValue(
+                      List(
+                        "argumentName" -> StringValue("id"),
+                        "code"         -> StringValue("BAD_USER_INPUT"),
+                        "exception"    -> ObjectValue(
+                          List("stacktrace" -> ListValue(List(StringValue("trace"))))
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      }
+    )
+}

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSInputJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSInputJsoniterSpec.scala
@@ -1,0 +1,36 @@
+package caliban.interop.jsoniter
+
+import caliban.{ GraphQLWSInput, InputValue, Value }
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, assertTrue, ZIOSpecDefault }
+
+object GraphQLWSInputJsoniterSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("GraphQLWSInputJsoniterSpec")(
+      test("can be parsed from JSON by jsoniter") {
+        val request =
+          """{"id":"id","type":"some type","payload":{"field":"yo"}}"""
+
+        val res = readFromString[GraphQLWSInput](request)
+        assert(res)(
+          equalTo(
+            GraphQLWSInput(
+              `type` = "some type",
+              id = Some("id"),
+              payload = Some(InputValue.ObjectValue(Map("field" -> Value.StringValue("yo"))))
+            )
+          )
+        )
+      },
+      test("can encode to JSON by jsoniter") {
+        val res = GraphQLWSInput(
+          `type` = "some type",
+          id = Some("id"),
+          payload = Some(InputValue.ObjectValue(Map("field" -> Value.StringValue("yo"))))
+        )
+
+        assertTrue(writeToString(res) == """{"type":"some type","id":"id","payload":{"field":"yo"}}""")
+      }
+    )
+}

--- a/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSOutputJsoniterSpec.scala
+++ b/core/src/test/scala/caliban/interop/jsoniter/GraphQLWSOutputJsoniterSpec.scala
@@ -1,0 +1,36 @@
+package caliban.interop.jsoniter
+
+import caliban.{ GraphQLWSOutput, ResponseValue, Value }
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import zio.test.Assertion.equalTo
+import zio.test.{ assert, assertTrue, ZIOSpecDefault }
+
+object GraphQLWSOutputJsoniterSpec extends ZIOSpecDefault {
+  override def spec =
+    suite("GraphQLWSOutputJsoniter")(
+      test("can be parsed from JSON by jsoniter") {
+        val request =
+          """{"id":"id","type":"some type","payload":{"field":"yo"}}"""
+
+        val res = readFromString[GraphQLWSOutput](request)
+        assert(res)(
+          equalTo(
+            GraphQLWSOutput(
+              `type` = "some type",
+              id = Some("id"),
+              payload = Some(ResponseValue.ObjectValue(List("field" -> Value.StringValue("yo"))))
+            )
+          )
+        )
+      },
+      test("can encode to JSON by jsoniter") {
+        val res = GraphQLWSOutput(
+          `type` = "some type",
+          id = Some("id"),
+          payload = Some(ResponseValue.ObjectValue(List("field" -> Value.StringValue("yo"))))
+        )
+
+        assertTrue(writeToString(res) == """{"type":"some type","id":"id","payload":{"field":"yo"}}""")
+      }
+    )
+}

--- a/interop/cats/src/test/scala/caliban/interop/cats/CatsInteropSpec.scala
+++ b/interop/cats/src/test/scala/caliban/interop/cats/CatsInteropSpec.scala
@@ -25,7 +25,7 @@ object CatsInteropSpec extends ZIOSpecDefault {
       val inner   = RootContext(SecurityContext(true), LogContext("internal-trace-id"))
 
       def main(inner: RootContext)(implicit runtime: Runtime[RootContext]) =
-        Dispatcher[Effect].use { dispatcher =>
+        Dispatcher.sequential[Effect].use { dispatcher =>
           program[Effect, RootContext](CatsInterop.contextual(dispatcher), inner)
         }
 
@@ -43,7 +43,7 @@ object CatsInteropSpec extends ZIOSpecDefault {
       val inner   = Context("internal-trace-id")
 
       def main(inner: Context)(implicit runtime: Runtime[Context]) =
-        Dispatcher[Effect].use { dispatcher =>
+        Dispatcher.sequential[Effect].use { dispatcher =>
           program[Effect, Context](CatsInterop.default(dispatcher), inner)
         }
 


### PR DESCRIPTION
### TODO

- [ ] Figure out a good approach to max-recursion depth (currently hardcoded to 512). Caliban allows to limit the depth of a query but __I think__ that part is applied after the JSON parsing
- [ ] Check whether it's possible to make the code a bit more generic to avoid duplication of encoder/decoders for `InputValue` and `ResponseValue`